### PR TITLE
changed not exported symbol bt:lock to bt::lock

### DIFF
--- a/src/nrt.lisp
+++ b/src/nrt.lisp
@@ -246,7 +246,7 @@ undefined.")
 (declaim (type boolean *alloc-nrt-memory-p*))
 
 (defglobal *nrt-memory-lock* (bt:make-lock "NRT-MEMORY-LOCK"))
-(declaim (type bt:lock *nrt-memory-lock*))
+(declaim (type bt::lock *nrt-memory-lock*))
 
 (defun realloc-nrt-input-buffer ()
   (foreign-free *%nrt-input-pointer*)


### PR DESCRIPTION
Compiling incudine triggered an error on OSX about bt:lock not being external in bordeaux-threads.