### PR TITLE
Reorder cffi definitions to avoid build problem.

### DIFF
--- a/contrib/cl-sndfile/cffi-sndfile.lisp
+++ b/contrib/cl-sndfile/cffi-sndfile.lisp
@@ -29,6 +29,18 @@
   (unless (cffi:foreign-library-loaded-p 'sndfile)
     (load-sndfile-library)))
 
+(cffi:defctype sf-count :int64)
+;; Alias.
+(cffi:defctype count :int64)
+
+(cffi:defcstruct info
+  (frames sf-count)
+  (sample-rate :int)
+  (channels :int)
+  (format :int)
+  (sections :int)
+  (seekable :int))
+
 (defstruct (pointer-wrapper (:constructor %make-pointer-wrapper))
   (pointer (cffi:null-pointer) :type cffi:foreign-pointer))
 
@@ -390,14 +402,6 @@
 (cffi:defctype sf-count :int64)
 ;; Alias.
 (cffi:defctype count :int64)
-
-(cffi:defcstruct info
-  (frames sf-count)
-  (sample-rate :int)
-  (channels :int)
-  (format :int)
-  (sections :int)
-  (seekable :int))
 
 (cffi:defcstruct format-info
   (format :int)


### PR DESCRIPTION
I had to make this change in order to avoid this build problem:
```
; compiling file "/home/green/git/incudine/contrib/cl-sndfile/cffi-sndfile.lisp" (written 20 AUG 2024 11:00:04 AM):

; file: /home/green/git/incudine/contrib/cl-sndfile/cffi-sndfile.lisp
; in: DEFUN MAKE-SNDINFO
;     (CFFI:FOREIGN-TYPE-SIZE '(:STRUCT SNDFILE:INFO))
; 
; caught WARNING:
;   Error during compiler-macroexpansion of
;   (CFFI:FOREIGN-TYPE-SIZE '(:STRUCT INFO)). Use *BREAK-ON-SIGNALS* to intercept.
;   
;    Unknown CFFI type (:STRUCT INFO)
```